### PR TITLE
ci: make Playwright Docker E2E resilient to version bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,10 @@ updates:
       prefix: "fix" # production deps → fix(deps): → patch release via Release Please
       prefix-development: "chore" # dev deps → chore(deps-dev): → no release, listed under Maintenance
       include: "scope" # append (deps)/(deps-dev) scope to the prefix
+    groups:
+      # Keep @playwright/test, playwright(-core) and @axe-core/playwright in a
+      # single PR so the whole Playwright stack moves together (avoids partial
+      # lockfile dedupe between @playwright/test and @axe-core/playwright's peer).
+      playwright:
+        patterns:
+          - "*playwright*"

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -17,6 +17,12 @@ COPY apps/docs/package.json ./apps/docs/
 # Install dependencies (skip frozen for cross-platform compatibility)
 RUN bun install
 
+# Install the browser binary matching the resolved Playwright version.
+# The base image ships browsers pinned to its tag, which drifts out of sync
+# whenever Dependabot bumps @playwright/test. Installing here keeps the browser
+# revision aligned with the lockfile regardless of the base image tag.
+RUN bunx playwright install chromium
+
 # Copy source
 COPY . .
 


### PR DESCRIPTION
## Why

Every Dependabot bump of `@playwright/test` broke CI in two ways (most recently #105):

1. **E2E** — `Dockerfile.test` pinned `FROM mcr.microsoft.com/playwright:v1.60.0-jammy`, whose baked-in browser binaries drift out of sync with the bumped runtime → `Executable doesn't exist at .../chromium_headless_shell-*`. Dependabot's `bun` ecosystem never edits Dockerfiles, so this recurred on every bump.
2. **Typecheck** — a partial bun lockfile dedupe left two `playwright-core` copies (`@axe-core/playwright`'s wide peer kept the old one), producing incompatible `Page` types (`TS2322`).

## What

- **`Dockerfile.test`**: install the chromium binary at build time (`bunx playwright install chromium`) so the browser revision always matches the resolved Playwright version, regardless of the base image tag. This durably kills failure mode 1.
- **`.github/dependabot.yml`**: group all `*playwright*` packages into a single PR so `@playwright/test` and `@axe-core/playwright` move together, reducing the lockfile-dedupe churn behind failure mode 2.

## Validation

`bun run test:docker` — builds the image and runs the visual suite: **30 visual tests pass**.