### PR TITLE
fix(core): fix a11y test failures after playwright 1.62.1 update

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.62.0-jammy
+FROM mcr.microsoft.com/playwright:v1.62.1-jammy
 
 # Create non-root user
 RUN useradd --create-home --shell /bin/bash playwright

--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "shift-css",
+      "dependencies": {
+        "@axe-core/playwright": "^4.12.1",
+      },
       "devDependencies": {
         "@biomejs/biome": "^2.5.6",
       },
@@ -39,7 +42,7 @@
       "devDependencies": {
         "@types/bun": "^1.3.14",
         "@types/node": "^26.1.2",
-        "tsx": "^4.23.1",
+        "tsx": "^4.23.5",
         "typescript": "7.0.2",
       },
     },
@@ -48,12 +51,13 @@
       "version": "0.8.2",
       "devDependencies": {
         "@axe-core/playwright": "^4.12.1",
-        "@playwright/test": "^1.62.0",
+        "@playwright/test": "^1.62.1",
         "@types/bun": "^1.3.14",
         "@types/node": "^26.1.2",
-        "@types/react": "^19.2.17",
+        "@types/react": "^19.2.18",
         "lightningcss": "^1.33.0",
-        "tsx": "^4.23.1",
+        "playwright-core": "^1.62.1",
+        "tsx": "^4.23.5",
         "typescript": "^7.0.2",
         "vue": "^3.5.40",
       },
@@ -327,7 +331,7 @@
 
     "@pagefind/windows-x64": ["@pagefind/windows-x64@1.5.2", "", { "os": "win32", "cpu": "x64" }, "sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg=="],
 
-    "@playwright/test": ["@playwright/test@1.62.0", "", { "dependencies": { "playwright": "1.62.0" }, "bin": { "playwright": "cli.js" } }, "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA=="],
+    "@playwright/test": ["@playwright/test@1.62.1", "", { "dependencies": { "playwright": "1.62.1" }, "bin": { "playwright": "cli.js" } }, "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.5", "", { "os": "android", "cpu": "arm64" }, "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ=="],
 
@@ -407,7 +411,7 @@
 
     "@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
 
-    "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
+    "@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
 
     "@types/sax": ["@types/sax@1.2.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A=="],
 
@@ -917,9 +921,9 @@
 
     "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
-    "playwright": ["playwright@1.62.0", "", { "dependencies": { "playwright-core": "1.62.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw=="],
+    "playwright": ["playwright@1.62.1", "", { "dependencies": { "playwright-core": "1.62.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg=="],
 
-    "playwright-core": ["playwright-core@1.62.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA=="],
+    "playwright-core": ["playwright-core@1.62.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw=="],
 
     "postcss": ["postcss@8.5.23", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg=="],
 
@@ -1033,7 +1037,7 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "tsx": ["tsx@4.23.1", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ=="],
+    "tsx": ["tsx@4.23.5", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-rw55FUaqOoI7RvlQwLbhO4nSDApnQ4/CykPuiQ/EPvtrX3WA9Ig55jIt9VvbBJbzJuj12ueRu4PMZ2SxPVbihg=="],
 
     "typesafe-path": ["typesafe-path@0.2.2", "", {}, "sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/bun": "^1.3.14",
     "@types/node": "^26.1.2",
-    "tsx": "^4.23.1",
+    "tsx": "^4.23.5",
     "typescript": "7.0.2"
   },
   "engines": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -61,12 +61,13 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.12.1",
-    "@playwright/test": "^1.62.0",
+    "@playwright/test": "^1.62.1",
     "@types/bun": "^1.3.14",
     "@types/node": "^26.1.2",
-    "@types/react": "^19.2.17",
+    "@types/react": "^19.2.18",
     "lightningcss": "^1.33.0",
-    "tsx": "^4.23.1",
+    "playwright-core": "^1.62.1",
+    "tsx": "^4.23.5",
     "typescript": "^7.0.2",
     "vue": "^3.5.40"
   },

--- a/packages/core/tests/e2e/accessibility.a11y.ts
+++ b/packages/core/tests/e2e/accessibility.a11y.ts
@@ -8,127 +8,135 @@ import { AxeBuilder } from '@axe-core/playwright';
 import { expect, test } from '@playwright/test';
 
 test.describe('Accessibility - Color Contrast', () => {
-	test('colors page passes axe contrast checks - light mode', async ({ page }) => {
-		await page.emulateMedia({ colorScheme: 'light' });
-		await page.goto('/colors.html');
-		await page.waitForTimeout(100);
+	test.describe('light mode', () => {
+		test.use({ colorScheme: 'light' });
 
-		// Test UI controls only (not color swatches which intentionally show all color steps)
-		// Color swatches are excluded since they demonstrate the full scale range
-		const accessibilityScanResults = await new AxeBuilder({ page })
-			.withTags(['wcag2aa'])
-			.exclude('.color-swatch') // Color palette demonstrations aren't subject to contrast rules
-			.exclude('.step-labels') // Step labels are decorative context
-			.analyze();
+		test('colors page passes axe contrast checks', async ({ page }) => {
+			await page.goto('/colors.html');
+			await page.waitForTimeout(100);
 
-		// Only check AA contrast (4.5:1), not AAA (7:1)
-		const contrastViolations = accessibilityScanResults.violations.filter(
-			(v: { id: string }) => v.id === 'color-contrast'
-		);
+			const accessibilityScanResults = await new AxeBuilder({ page })
+				.withTags(['wcag2aa'])
+				.exclude('.color-swatch')
+				.exclude('.step-labels')
+				.analyze();
 
-		expect(contrastViolations).toHaveLength(0);
-	});
+			const contrastViolations = accessibilityScanResults.violations.filter(
+				(v: { id: string }) => v.id === 'color-contrast'
+			);
 
-	test('colors page passes axe contrast checks - dark mode', async ({ page }) => {
-		await page.emulateMedia({ colorScheme: 'dark' });
-		await page.goto('/colors.html');
-		await page.waitForTimeout(100);
+			expect(contrastViolations).toHaveLength(0);
+		});
 
-		// Test UI controls only (not color swatches which intentionally show all color steps)
-		const accessibilityScanResults = await new AxeBuilder({ page })
-			.withTags(['wcag2aa'])
-			.exclude('.color-swatch')
-			.exclude('.step-labels')
-			.analyze();
+		test('contrast test page passes axe checks', async ({ page }) => {
+			await page.goto('/contrast.html');
+			await page.waitForTimeout(100);
 
-		const contrastViolations = accessibilityScanResults.violations.filter(
-			(v: { id: string }) => v.id === 'color-contrast'
-		);
+			const accessibilityScanResults = await new AxeBuilder({ page })
+				.withTags(['wcag2aa'])
+				.analyze();
 
-		expect(contrastViolations).toHaveLength(0);
-	});
+			const contrastViolations = accessibilityScanResults.violations.filter(
+				(v: { id: string }) => v.id === 'color-contrast'
+			);
 
-	test('contrast test page passes axe checks - light mode', async ({ page }) => {
-		await page.emulateMedia({ colorScheme: 'light' });
-		await page.goto('/contrast.html');
-		await page.waitForTimeout(100);
-
-		const accessibilityScanResults = await new AxeBuilder({ page }).withTags(['wcag2aa']).analyze();
-
-		const contrastViolations = accessibilityScanResults.violations.filter(
-			(v: { id: string }) => v.id === 'color-contrast'
-		);
-
-		// Log any violations for debugging
-		if (contrastViolations.length > 0) {
-			console.log('Contrast violations found:');
-			for (const violation of contrastViolations) {
-				for (const node of violation.nodes) {
-					console.log(`  - ${node.html}`);
-					console.log(`    ${node.failureSummary}`);
+			if (contrastViolations.length > 0) {
+				console.log('Contrast violations found:');
+				for (const violation of contrastViolations) {
+					for (const node of violation.nodes) {
+						console.log(`  - ${node.html}`);
+						console.log(`    ${node.failureSummary}`);
+					}
 				}
 			}
-		}
 
-		expect(contrastViolations).toHaveLength(0);
+			expect(contrastViolations).toHaveLength(0);
+		});
 	});
 
-	test('contrast test page passes axe checks - dark mode', async ({ page }) => {
-		await page.emulateMedia({ colorScheme: 'dark' });
-		await page.goto('/contrast.html');
-		await page.waitForTimeout(100);
+	test.describe('dark mode', () => {
+		test.use({ colorScheme: 'dark' });
 
-		const accessibilityScanResults = await new AxeBuilder({ page }).withTags(['wcag2aa']).analyze();
+		test('colors page passes axe contrast checks', async ({ page }) => {
+			await page.goto('/colors.html');
+			await page.waitForTimeout(100);
 
-		const contrastViolations = accessibilityScanResults.violations.filter(
-			(v: { id: string }) => v.id === 'color-contrast'
-		);
+			const accessibilityScanResults = await new AxeBuilder({ page })
+				.withTags(['wcag2aa'])
+				.exclude('.color-swatch')
+				.exclude('.step-labels')
+				.analyze();
 
-		if (contrastViolations.length > 0) {
-			console.log('Dark mode contrast violations found:');
-			for (const violation of contrastViolations) {
-				for (const node of violation.nodes) {
-					console.log(`  - ${node.html}`);
-					console.log(`    ${node.failureSummary}`);
+			const contrastViolations = accessibilityScanResults.violations.filter(
+				(v: { id: string }) => v.id === 'color-contrast'
+			);
+
+			expect(contrastViolations).toHaveLength(0);
+		});
+
+		test('contrast test page passes axe checks', async ({ page }) => {
+			await page.goto('/contrast.html');
+			await page.waitForTimeout(100);
+
+			const accessibilityScanResults = await new AxeBuilder({ page })
+				.withTags(['wcag2aa'])
+				.analyze();
+
+			const contrastViolations = accessibilityScanResults.violations.filter(
+				(v: { id: string }) => v.id === 'color-contrast'
+			);
+
+			if (contrastViolations.length > 0) {
+				console.log('Dark mode contrast violations found:');
+				for (const violation of contrastViolations) {
+					for (const node of violation.nodes) {
+						console.log(`  - ${node.html}`);
+						console.log(`    ${node.failureSummary}`);
+					}
 				}
 			}
-		}
 
-		expect(contrastViolations).toHaveLength(0);
+			expect(contrastViolations).toHaveLength(0);
+		});
 	});
 });
 
 test.describe('Accessibility - Components', () => {
-	test('components page has no accessibility violations - light mode', async ({ page }) => {
-		await page.emulateMedia({ colorScheme: 'light' });
-		await page.goto('/components.html');
-		await page.waitForTimeout(100);
+	test.describe('light mode', () => {
+		test.use({ colorScheme: 'light' });
 
-		const accessibilityScanResults = await new AxeBuilder({ page })
-			.withTags(['wcag2aa', 'wcag21aa'])
-			.analyze();
+		test('components page has no accessibility violations', async ({ page }) => {
+			await page.goto('/components.html');
+			await page.waitForTimeout(100);
 
-		expect(accessibilityScanResults.violations).toHaveLength(0);
+			const accessibilityScanResults = await new AxeBuilder({ page })
+				.withTags(['wcag2aa', 'wcag21aa'])
+				.analyze();
+
+			expect(accessibilityScanResults.violations).toHaveLength(0);
+		});
 	});
 
-	test('components page has no accessibility violations - dark mode', async ({ page }) => {
-		await page.emulateMedia({ colorScheme: 'dark' });
-		await page.goto('/components.html');
-		await page.waitForTimeout(100);
+	test.describe('dark mode', () => {
+		test.use({ colorScheme: 'dark' });
 
-		const accessibilityScanResults = await new AxeBuilder({ page })
-			.withTags(['wcag2aa', 'wcag21aa'])
-			.analyze();
+		test('components page has no accessibility violations', async ({ page }) => {
+			await page.goto('/components.html');
+			await page.waitForTimeout(100);
 
-		expect(accessibilityScanResults.violations).toHaveLength(0);
+			const accessibilityScanResults = await new AxeBuilder({ page })
+				.withTags(['wcag2aa', 'wcag21aa'])
+				.analyze();
+
+			expect(accessibilityScanResults.violations).toHaveLength(0);
+		});
 	});
 
 	test('buttons are keyboard accessible', async ({ page }) => {
 		await page.goto('/components.html');
 
-		// Tab to first button and check it receives focus
 		await page.keyboard.press('Tab');
-		await page.keyboard.press('Tab'); // Skip nav links
+		await page.keyboard.press('Tab');
 
 		const focusedElement = await page.evaluate(() => document.activeElement?.hasAttribute('s-btn'));
 
@@ -152,31 +160,28 @@ test.describe('Accessibility - Components', () => {
 });
 
 test.describe('Accessibility - Focus Indicators', () => {
+	test.use({ colorScheme: 'light' });
+
 	test('buttons have visible focus indicators', async ({ page }) => {
-		await page.emulateMedia({ colorScheme: 'light' });
 		await page.goto('/components.html');
 
 		const button = page.locator('[s-btn="primary"]').first();
 		await button.focus();
 
-		// Check that focus outline is visible
 		const outlineWidth = await button.evaluate((el) => {
 			const styles = window.getComputedStyle(el);
 			return styles.outlineWidth;
 		});
 
-		// Focus indicator should be present
 		expect(outlineWidth).not.toBe('0px');
 	});
 
 	test('inputs have visible focus indicators', async ({ page }) => {
-		await page.emulateMedia({ colorScheme: 'light' });
 		await page.goto('/components.html');
 
 		const input = page.locator('#text-input');
 		await input.focus();
 
-		// Check that focus ring is visible
 		const ringColor = await input.evaluate((el) => {
 			const styles = window.getComputedStyle(el);
 			return styles.outlineColor || styles.boxShadow;
@@ -187,8 +192,9 @@ test.describe('Accessibility - Focus Indicators', () => {
 });
 
 test.describe('Accessibility - Semantic Color Messages', () => {
+	test.use({ colorScheme: 'light' });
+
 	test('success messages have sufficient contrast', async ({ page }) => {
-		await page.emulateMedia({ colorScheme: 'light' });
 		await page.goto('/contrast.html');
 		await page.waitForTimeout(100);
 
@@ -211,15 +217,12 @@ test.describe('Accessibility - Screen Reader Utilities', () => {
 
 		const srOnlyLabel = page.locator('[data-testid="sr-only-label"]');
 
-		// Element should exist in DOM
 		await expect(srOnlyLabel).toBeAttached();
 
-		// Element should have sr-only styling (1px dimensions, clipped)
 		const box = await srOnlyLabel.boundingBox();
 		expect(box?.width).toBeLessThanOrEqual(1);
 		expect(box?.height).toBeLessThanOrEqual(1);
 
-		// Element should contain accessible text
 		await expect(srOnlyLabel).toHaveText('More options');
 	});
 
@@ -228,16 +231,13 @@ test.describe('Accessibility - Screen Reader Utilities', () => {
 
 		const skipLink = page.locator('[data-testid="skip-link"]');
 
-		// Before focus: should be visually hidden (off-screen or clipped)
 		const initialBox = await skipLink.boundingBox();
 		const isInitiallyHidden =
 			!initialBox || initialBox.width <= 1 || initialBox.height <= 1 || initialBox.y < 0;
 		expect(isInitiallyHidden).toBe(true);
 
-		// Focus the skip link (it's the first focusable element)
 		await skipLink.focus();
 
-		// After focus: should be visible with normal dimensions
 		const focusedBox = await skipLink.boundingBox();
 		expect(focusedBox).not.toBeNull();
 		expect(focusedBox!.width).toBeGreaterThan(1);
@@ -247,13 +247,11 @@ test.describe('Accessibility - Screen Reader Utilities', () => {
 	test('skip link is keyboard accessible', async ({ page }) => {
 		await page.goto('/components.html');
 
-		// Tab to focus the skip link (first focusable element)
 		await page.keyboard.press('Tab');
 
 		const skipLink = page.locator('[data-testid="skip-link"]');
 		await expect(skipLink).toBeFocused();
 
-		// Should now be visible
 		const box = await skipLink.boundingBox();
 		expect(box).not.toBeNull();
 		expect(box!.width).toBeGreaterThan(1);


### PR DESCRIPTION
## Summary

Fixes a11y test failures caused by the Playwright 1.62.0 to 1.62.1 dependency bump in PR #133.

## Changes

- Replace page.emulateMedia() with test.use({ colorScheme }) in a11y tests to fix parallel execution race condition where light-dark() resolved to light mode values, producing false contrast violations
- Add playwright-core as direct devDependency in packages/core/package.json to deduplicate types and resolve typecheck errors from stale 1.62.0 type references
- Bump Dockerfile playwright image to match 1.62.1
